### PR TITLE
Replace pdf-lib with pdfjs text extraction

### DIFF
--- a/lib/parsers.ts
+++ b/lib/parsers.ts
@@ -1,18 +1,15 @@
 import mammoth from 'mammoth';
-import { PDFDocument } from 'pdf-lib';
+import { extractPdfText } from '../app/utils/extractPdfText';
 
 export async function parseFileContent(buffer: Buffer, mimetype: string): Promise<string> {
   if (mimetype === 'application/pdf') {
-    const pdfDoc = await PDFDocument.load(buffer);
-    const pages = pdfDoc.getPages();
-    let text = '';
-
-    for (const page of pages) {
-      const content = page.getTextContent?.(); // may be undefined in some builds
-      if (content) text += content;
+    try {
+      const text = await extractPdfText(buffer);
+      return text || '[No text extracted from PDF]';
+    } catch (err: any) {
+      console.error('PDF extraction failed:', err);
+      return `[PDF extraction failed: ${err?.message || err}]`;
     }
-
-    return text || '[No text extracted from PDF]';
   }
 
   if (mimetype === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document') {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "tsx tests/parsers.test.ts"
   },
   "dependencies": {
     "@auth/core": "0.39.1",

--- a/tests/parsers.test.ts
+++ b/tests/parsers.test.ts
@@ -1,0 +1,12 @@
+import fs from 'fs';
+import assert from 'assert';
+import { parseFileContent } from '../lib/parsers';
+
+(async () => {
+  const buffer = fs.readFileSync('app/public/test-docs/Parenting-Plan.pdf');
+  const text = await parseFileContent(buffer, 'application/pdf');
+  assert.ok(text && text.length > 0, 'Should extract some text from PDF');
+  assert.ok(/COURT/i.test(text), 'Extracted text should contain known phrase');
+  console.log('PDF parsing test passed');
+})();
+


### PR DESCRIPTION
## Summary
- switch PDF parsing to use `extractPdfText`
- add a small test for PDF parsing

## Testing
- `npm run test`
- `npm run lint` *(fails: asks to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_685b16b689c883299f9c7c456263a6ae