### PR TITLE
Update authOptions import in upload API

### DIFF
--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth'; // ✅ Confirm this matches your path
+import { authOptions } from '@/lib/authOptions';
 import { prisma } from '@/lib/prisma';
 import { parseFileContent } from '@/lib/parsers';
 


### PR DESCRIPTION
## Summary
- use `@/lib/authOptions` when importing auth options in the upload route

## Testing
- `npm install --legacy-peer-deps`
- `npx tsc` *(fails: Cannot find module '@/utils/extractPdfText', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685b16c0750c8329aea749ced9607456